### PR TITLE
Update host-records.txt

### DIFF
--- a/DNS/host-records.txt
+++ b/DNS/host-records.txt
@@ -1,5 +1,5 @@
 host-record=forcesafesearch.google.com,216.239.38.120
-host-record=safe.duckduckgo.com,54.241.17.246
+host-record=safe.duckduckgo.com,52.142.126.100
 host-record=restrict.youtube.com,216.239.38.120
 host-record=restrictmoderate.youtube.com,216.239.38.119
 host-record=strict.bing.com,204.79.197.220


### PR DESCRIPTION
I noticed that sometime in the last few weeks duckduckgo was not resolving on computers using this setup on pi-hole.
When I do `ping safe.duckduckgo.com` I get `52.142.126.100` which doesn't match the IP in the generated `05-restrict.conf` file in `/etc/dnsmasq.d/`. I edited that line to the current IP and duckduckgo resolves once more (in safe mode). This edit in host-records.txt should force the current settings during setup.

Thanks so much for putting this together!